### PR TITLE
Organize models into subpackages

### DIFF
--- a/Examples/QM5/predict.py
+++ b/Examples/QM5/predict.py
@@ -20,7 +20,7 @@ __dir__ = os.path.dirname(os.path.abspath(__dir__))
 sys.path.append(__dir__)
 sys.path.append(os.path.abspath(os.path.join(__dir__), "../.."))
 
-from QModels import QM5
+from QModels.QM5 import QM5
 from utils import utils
 
 waveform, sample_rate, label, speaker_id, utterance_number = train_set[0]

--- a/Examples/QM5/train.py
+++ b/Examples/QM5/train.py
@@ -17,7 +17,7 @@ __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
 sys.path.append(os.path.abspath(os.path.join(__dir__, "../..")))
 
-from QModels.qm5 import QM5
+from QModels.QM5 import QM5
 from utils import utils
 
 #print(len(train_set))

--- a/Examples/QTransformerTTS/train.py
+++ b/Examples/QTransformerTTS/train.py
@@ -20,7 +20,7 @@ __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
 sys.path.append(os.path.abspath(os.path.join(__dir__, '../..')))
 
-from QModels.qtransformertts import QTransformerTTS
+from QModels.QTransformerTTS import QTransformerTTS
 
 
 def preprocess(data):

--- a/QModels/QM5/__init__.py
+++ b/QModels/QM5/__init__.py
@@ -1,0 +1,1 @@
+from .qm5 import QM5

--- a/QModels/QM5/qm5.py
+++ b/QModels/QM5/qm5.py
@@ -7,7 +7,7 @@ import sys
 
 __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
-sys.path.append(os.path.abspath(os.path.join(__dir__, "../..")))
+sys.path.append(os.path.abspath(os.path.join(__dir__, "../../..")))
 
 from QLayer.qconv import QCONV1d
 

--- a/QModels/QTacotron/__init__.py
+++ b/QModels/QTacotron/__init__.py
@@ -1,0 +1,1 @@
+from .qtacotron import QTacotron

--- a/QModels/QTacotron/qtacotron.py
+++ b/QModels/QTacotron/qtacotron.py
@@ -13,7 +13,7 @@ import sys
 
 __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
-sys.path.append(os.path.abspath(os.path.join(__dir__, '../..')))
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../../..')))
 
 from QLayer.qgru import QGRU
 

--- a/QModels/QTransformerTTS/__init__.py
+++ b/QModels/QTransformerTTS/__init__.py
@@ -1,0 +1,1 @@
+from .qtransformertts import QTransformerTTS

--- a/QModels/QTransformerTTS/qtransformertts.py
+++ b/QModels/QTransformerTTS/qtransformertts.py
@@ -7,8 +7,7 @@ import sys
 
 __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
-sys.path.append(os.path.abspath(os.path.join(__dir__, '../')))
-#sys.path.append(os.path.abspath(os.path.join(__dir__, '../'..)))
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../..')))
 
 from QLayer.qtransformer import QTransformerBlock
 from QLayer.qconv import QCONV_5x5, QCONV_1x1

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ For the hybrid quantum-classical neural networks in speech applications, we impl
 ## Basic framework
 - QCircuit: the variational quantum circuit(VQC) and low-qubit VQC.
 - QLayer: the qlstm, qgru, qattention, qconv.
-- QModels: the qm5, qtransformer, qtacotron.
+- QModels: the QM5, QTacotron and QTransformer-TTS models are now organized
+  into separate folders under `QModels`.
 
 ### Notes
 The code of qlstm and qtransformer are based on these two projects as follow: 


### PR DESCRIPTION
## Summary
- move each model into its own subdirectory under `QModels`
- update imports in example scripts
- document new structure in the README

## Testing
- `python -m py_compile QModels/QM5/qm5.py QModels/QTacotron/qtacotron.py QModels/QTransformerTTS/qtransformertts.py`
- `python -m py_compile Examples/QM5/train.py Examples/QM5/predict.py Examples/QTransformerTTS/train.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68459fecf3f0832f922c204acd324823